### PR TITLE
Fix for Template.load()

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -228,7 +228,7 @@ class Template {
     const typeIdentifier = passJson.passTypeIdentifier;
     const keyName = `${typeIdentifier.replace(/^pass\./, '')}.pem`;
     try {
-      const keyStat = await statAsync(keyName);
+      const keyStat = await statAsync(join(folderPath, keyName));
       if (keyStat.isFile()) template.keys(folderPath, keyPassword);
     } catch (_) {} // eslint-disable
 


### PR DESCRIPTION
The Template.load() did not use the folderPath to search for the key file.