### PR TITLE
Throw error when no key certs found

### DIFF
--- a/src/lib/decodePrivateKey.js
+++ b/src/lib/decodePrivateKey.js
@@ -10,6 +10,10 @@ function decodePrivateKey(keydata, password, returnPEM = false) {
     message.type.includes('KEY'),
   );
 
+  if (!signerKeyMessage) {
+    throw new Error('Invalid certificate, no key found');
+  }
+
   const key = forge.pki.decryptRsaPrivateKey(
     forge.pem.encode(signerKeyMessage),
     password,


### PR DESCRIPTION
Currently, when using a malformed certificate that doesn't contain any private keys, the following error is printed to the console.

    (node:7839) UnhandledPromiseRejectionWarning: Unhandled promise rejection
    (rejection id: 1): TypeError: Cannot read property 'type' of undefined

With this PR, the following error is thrown instead:

    (node:6872) UnhandledPromiseRejectionWarning: Unhandled promise rejection
    (rejection id: 1): Error: Invalid certificate, no key found

Thanks for the awesome project ✨ 