### PR TITLE
Add option to set certificate authority file path

### DIFF
--- a/__tests__/signManifest.js
+++ b/__tests__/signManifest.js
@@ -12,6 +12,7 @@ test('signManifest', async () => {
     path.resolve(__dirname, '../keys/com.example.passbook.pem'),
     'secret',
     TEST_STRING,
+    'keys/wwdr.pem',
   );
   expect(Buffer.isBuffer(jsSignedBuffer)).toBeTruthy();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@destinationstransfers/passkit",
-  "version": "4.3.2",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/signManifest-forge.js
+++ b/src/lib/signManifest-forge.js
@@ -6,11 +6,6 @@ const {
   promises: { readFile },
   readFileSync,
 } = require('fs');
-const { resolve } = require('path');
-
-const APPLE_CA_CERTIFICATE = forge.pki.certificateFromPem(
-  readFileSync(resolve(__dirname, '../../keys/wwdr.pem'), 'utf8'),
-);
 
 /**
  * Signs a manifest and returns the signature.
@@ -18,9 +13,18 @@ const APPLE_CA_CERTIFICATE = forge.pki.certificateFromPem(
  * @param {string} signerPemFile - signing certificate filename
  * @param {string} password - certificate password
  * @param {string} manifest - manifest to sign
+ * @param {string} certificateAuthorityFile - apple wwdr certificate filename
  * @returns {Promise.<Buffer>} - signature for given manifest
  */
-async function signManifest(signerPemFile, password, manifest) {
+async function signManifest(
+  signerPemFile,
+  password,
+  manifest,
+  certificateAuthorityFile,
+) {
+  const APPLE_CA_CERTIFICATE = forge.pki.certificateFromPem(
+    readFileSync(certificateAuthorityFile, 'utf8'),
+  );
   // reading and parsing certificates
   const signerCertData = await readFile(signerPemFile, 'utf8');
   // the PEM file from P12 contains both, certificate and private key

--- a/src/pass.js
+++ b/src/pass.js
@@ -415,6 +415,7 @@ class Pass extends EventEmitter {
       path.resolve(this.template.keysPath, `${identifier}.pem`),
       this.template.password,
       manifestJson,
+      this.template.caKeysPath,
     );
     zip.addBuffer(signature, 'signature', { compress: false });
 

--- a/src/template.js
+++ b/src/template.js
@@ -39,7 +39,7 @@ class Template {
     }
 
     this.keysPath = 'keys';
-    this.caKeysPath = 'keys/wwdr.pem';
+    this.caKeysPath = path.resolve(__dirname, '../keys/wwdr.pem');
     this.password = null;
     this.apn = null;
     this.images = new PassImages();

--- a/src/template.js
+++ b/src/template.js
@@ -39,6 +39,7 @@ class Template {
     }
 
     this.keysPath = 'keys';
+    this.caKeysPath = 'keys/wwdr.pem';
     this.password = null;
     this.apn = null;
     this.images = new PassImages();
@@ -254,6 +255,10 @@ class Template {
   keys(keysPath, password) {
     if (typeof keysPath === 'string') this.keysPath = keysPath;
     if (password) this.password = password;
+  }
+
+  caKeys(caKeysPath) {
+    if (typeof caKeysPath === 'string') this.caKeysPath = caKeysPath;
   }
 
   /**

--- a/src/template.js
+++ b/src/template.js
@@ -257,6 +257,12 @@ class Template {
     if (password) this.password = password;
   }
 
+  /**
+   * Sets filename to certificate authority.
+   *
+   * @param {string} caKeysPath - Filename for certificate authority (default is 'keys/wwdr.pem')
+   * @memberof Template
+   */
   caKeys(caKeysPath) {
     if (typeof caKeysPath === 'string') this.caKeysPath = caKeysPath;
   }


### PR DESCRIPTION
When bundling passkit into a single JavaScript file the path for wwdr.pem is wrong. This is because of how `__dirname` changes. This causes the certificate to not be found and passkit crashes.

My proposed solution is introducing a new option that lets you set an arbitrary file path to the `wwdr.pem` file, so you can put it in a location where you can be sure it will be available after bundling.

The old behavior is still preserved so this should not be a breaking change.